### PR TITLE
Fixes the imctoools version to v1.0.7

### DIFF
--- a/setup/conda_imctools.yml
+++ b/setup/conda_imctools.yml
@@ -16,4 +16,4 @@ dependencies:
   - scipy
   - git
   - pip:
-        - "git+https://github.com/BodenmillerGroup/imctools.git@master"
+        - imctools=1.0.7

--- a/setup/conda_imctools.yml
+++ b/setup/conda_imctools.yml
@@ -16,4 +16,4 @@ dependencies:
   - scipy
   - git
   - pip:
-        - imctools=1.0.7
+        - imctools==1.0.7


### PR DESCRIPTION
Imctools is currently being updated to v2, introducing incompatible changes.
This should fix the version to the latest v1 until the script is update.