### PR TITLE
Hotfix xtiff/tifffile issue

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -10,7 +10,7 @@ install_requires =
     pandas
     readimc
     scipy
-    tifffile
+    tifffile<2022.4.22
     xtiff
 python_requires = >=3.8
 package_dir =


### PR DESCRIPTION
As a workaround, following #90, pin tifffile to versions <2022.4.22, while waiting for https://github.com/BodenmillerGroup/xtiff/issues/10